### PR TITLE
Develop

### DIFF
--- a/refuerzo-apiv2/src/users/users.service.ts
+++ b/refuerzo-apiv2/src/users/users.service.ts
@@ -528,7 +528,6 @@ export class UsersService {
 
     const updates: Partial<User> = {};
 
-    console.log(updateProfileDto.image);
     if (updateProfileDto.image) {
       updates.image = updateProfileDto.image;
     }
@@ -545,7 +544,6 @@ export class UsersService {
     }
 
     updates.isActive = true;
-    console.log('updates', updates);
     await this.crudHelper.update(user, updates);
 
     return new GeneralResponseBuilder<User>()

--- a/refuerzo-web/components/Auth/UpdateRequiredForm.tsx
+++ b/refuerzo-web/components/Auth/UpdateRequiredForm.tsx
@@ -188,10 +188,13 @@ const UpdateRequiredForm: React.FC<UpdateRequiredFormProps> = ({ username }) => 
           const usuario: ActivateAccountRequirements = {
             telefono: formData.current.telefono,
             password: formData.current.password,
-            imagen: imagenSubida.data.url, 
+            image: imagenSubida.data.url, 
           };
-      
+            
+            
         const response = await activateAccountMutator.mutateAsync(usuario);
+            
+        
 
         console.log(response);
           

--- a/refuerzo-web/services/user.service.ts
+++ b/refuerzo-web/services/user.service.ts
@@ -4,6 +4,8 @@ import { ActivateAccountRequirements } from '@/types/types';
 
 
 export const activeProfile = async (usuario: ActivateAccountRequirements): Promise<ActivateAccountRequirements> => {
+  console.log(usuario)
   const response = await api.patch<ActivateAccountRequirements>('/users/me/profile', usuario);
+  
   return response.data;
 };

--- a/refuerzo-web/types/types.ts
+++ b/refuerzo-web/types/types.ts
@@ -41,7 +41,7 @@ export interface Usuario {
 }
 
 export interface ActivateAccountRequirements {
-  imagen: string;
+  image: string;
   telefono: string;
   password: string;
 }


### PR DESCRIPTION
This pull request includes several changes aimed at cleaning up the code and ensuring consistency in naming conventions. The most important changes include the removal of console log statements, renaming a property for consistency, and adding a console log for debugging purposes.

Code cleanup:

* [`refuerzo-apiv2/src/users/users.service.ts`](diffhunk://#diff-2d99939eafe5ca5128db6705267966b9925fb2e11e49c87a985a81e4aa0114d1L531): Removed unnecessary console log statements in the `UsersService` class. [[1]](diffhunk://#diff-2d99939eafe5ca5128db6705267966b9925fb2e11e49c87a985a81e4aa0114d1L531) [[2]](diffhunk://#diff-2d99939eafe5ca5128db6705267966b9925fb2e11e49c87a985a81e4aa0114d1L548)

Consistency improvements:

* [`refuerzo-web/types/types.ts`](diffhunk://#diff-e117246de9bc3b8ee8c9ecc80c955310cc33c00c001c2faf4eaf2eeb2b8d3d70L44-R44): Renamed the `imagen` property to `image` in the `ActivateAccountRequirements` interface for consistency.
* [`refuerzo-web/components/Auth/UpdateRequiredForm.tsx`](diffhunk://#diff-28df0849f416e101f7e8a3574be7edcb8b04903199ff862a90a3a2457316f045L191-R198): Updated the property name from `imagen` to `image` in the `UpdateRequiredForm` component to match the interface change.

Debugging:

* [`refuerzo-web/services/user.service.ts`](diffhunk://#diff-3139638c63e0b3e8360bf13879c23f70964ea8e13225dacd5d2ed4c032a3bd67R7-R9): Added a console log statement to log the `usuario` object in the `activeProfile` function for debugging purposes.