### PR TITLE
🚧 Add password page verification

### DIFF
--- a/refuerzo-web/app/reset-password/page.tsx
+++ b/refuerzo-web/app/reset-password/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { resetPassword } from "@/services/user.service";
+import { Toaster } from "react-hot-toast";
+import toast from "react-hot-toast";
+
+const ResetPasswordPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      toast.error("Token inválido o enlace expirado");
+      router.push("/login");
+    }
+  }, [token, router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    if (newPassword !== confirmPassword) {
+      toast.error("Las contraseñas no coinciden");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      if (!token) throw new Error("Token inválido");
+      
+      await resetPassword(token, newPassword);
+      toast.success("¡Contraseña actualizada correctamente!");
+      setTimeout(() => router.push("/login"), 2000);
+    } catch{
+      toast.error("Error al actualizar la contraseña. El enlace puede haber expirado");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <Toaster position="top-center" />
+      <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-lg shadow-lg">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Restablecer Contraseña
+          </h2>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="rounded-md shadow-sm space-y-4">
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                Nueva Contraseña
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="••••••••"
+              />
+            </div>
+            <div>
+              <label htmlFor="confirm-password" className="block text-sm font-medium text-gray-700">
+                Confirmar Contraseña
+              </label>
+              <input
+                id="confirm-password"
+                name="confirm-password"
+                type="password"
+                required
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="••••••••"
+              />
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+            >
+              {loading ? "Procesando..." : "Restablecer Contraseña"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/refuerzo-web/components/Login/LoginForm.tsx
+++ b/refuerzo-web/components/Login/LoginForm.tsx
@@ -6,6 +6,10 @@ import { AuthService } from "@/services/auth.service";
 import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from 'next/navigation';
 import Image from "next/image";
+import { requestPasswordReset } from "@/services/user.service";
+import { RequestPassResponse } from "@/types/types";
+import toast from "react-hot-toast";
+import { Toaster } from "react-hot-toast";
 
 const LoginForm: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false);
@@ -13,6 +17,10 @@ const LoginForm: React.FC = () => {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [showForgotPasswordPopup, setShowForgotPasswordPopup] = useState(false);
+  const [resetEmail, setResetEmail] = useState("");
+  const [resetLoading, setResetLoading] = useState(false);
+
   const router = useRouter();
 
   useEffect(() => {
@@ -22,16 +30,14 @@ const LoginForm: React.FC = () => {
         router.push('/dashboard');
       }
     };
-    
+
     checkAuth();
   }, [router]);
-
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
     setLoading(true);
-
 
     try {
       await AuthService.login({ email, password });
@@ -48,11 +54,40 @@ const LoginForm: React.FC = () => {
     }
   };
 
+  const handleForgotPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setResetLoading(true);
 
-  
+    try {
+      const response: RequestPassResponse = await requestPasswordReset(resetEmail);
+
+      if (response && response.statusCode === 404) {
+        toast.error(response.message);
+      } else {
+        toast.success("Enlace de recuperación enviado correctamente, revisa tu correo.");
+        setShowForgotPasswordPopup(false);
+      }
+    } catch {
+      setError("Error al enviar el enlace de recuperación. Intenta nuevamente.");
+    } finally {
+      setResetLoading(false);
+    }
+  };
 
   return (
     <div className="w-full md:w-1/2 p-6 md:p-8">
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          duration: 5000,
+          style: {
+            background: "#fff",
+            color: "#363636",
+            boxShadow: "0 3px 10px rgba(0, 0, 0, 0.1)",
+          },
+        }}
+      />
       <Image src="/LogoColorido.svg" alt="Logo" className="w-24" width={96} height={96} />
       <h2 className="text-2xl font-bold mb-6 text-blue_principal">Iniciar Sesión</h2>
 
@@ -61,6 +96,22 @@ const LoginForm: React.FC = () => {
       )}
 
       <form className="space-y-4" onSubmit={handleSubmit}>
+        <div className="absolute -top-[1000px] left-0 opacity-0" aria-hidden="true">
+          <label htmlFor="website"></label>
+          <input
+            type="text"
+            id="website"
+            name="website"
+            tabIndex={-1}
+            autoComplete="off"
+            onChange={(e) => {
+              if (e.target.value) {
+                setError('Solicitud bloqueada por seguridad');
+                setResetLoading(false);
+              }
+            }}
+          />
+        </div>
         <div>
           <label
             htmlFor="email"
@@ -118,7 +169,67 @@ const LoginForm: React.FC = () => {
         >
           {loading ? "Cargando..." : "Iniciar Sesión"}
         </button>
+
+        <div className="text-center mt-4">
+          <button
+            type="button"
+            onClick={() => setShowForgotPasswordPopup(true)}
+            className="text-blue_principal hover:text-blue-700 text-sm"
+          >
+            ¿Olvidaste tu contraseña?
+          </button>
+        </div>
       </form>
+
+      {/* Popup de recuperación de contraseña */}
+      {showForgotPasswordPopup && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+            <h3 className="text-xl font-bold mb-4 text-blue_principal">Recuperar Contraseña</h3>
+
+            <>
+              <p className="mb-4 text-gray-600">
+                Ingresa tu email y te enviaremos un enlace para restablecer tu contraseña.
+              </p>
+
+              <form onSubmit={handleForgotPassword}>
+                <div className="mb-4">
+                  <label htmlFor="reset-email" className="block text-sm font-medium text-gray-700 mb-2">
+                    Email
+                  </label>
+                  <input
+                    type="email"
+                    id="reset-email"
+                    value={resetEmail}
+                    onChange={(e) => setResetEmail(e.target.value)}
+                    placeholder="nombre@ejemplo.com"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue_principal"
+                    required
+                  />
+                </div>
+
+                <div className="flex justify-end gap-4">
+                  <button
+                    type="button"
+                    onClick={() => setShowForgotPasswordPopup(false)}
+                    className="px-4 py-2 text-gray-600 hover:text-gray-800"
+                  >
+                    Cancelar
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={resetLoading}
+                    className="px-4 py-2 bg-blue_principal text-white rounded-md hover:bg-blue-600 disabled:opacity-50"
+                  >
+                    {resetLoading ? "Enviando..." : "Enviar enlace"}
+                  </button>
+                </div>
+              </form>
+            </>
+
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/refuerzo-web/services/user.service.ts
+++ b/refuerzo-web/services/user.service.ts
@@ -1,6 +1,6 @@
 import { api } from '@/lib/api';
 
-import { ActivateAccountRequirements } from '@/types/types';
+import { ActivateAccountRequirements, RequestPassResponse } from '@/types/types';
 
 
 export const activeProfile = async (usuario: ActivateAccountRequirements): Promise<ActivateAccountRequirements> => {
@@ -12,3 +12,17 @@ export const activeProfile = async (usuario: ActivateAccountRequirements): Promi
 export const deleteUser = async (id: string): Promise<void> => {
   await api.delete(`/users/${id}`);
 }
+
+export const requestPasswordReset = async (email: string): Promise<RequestPassResponse> => {
+  const response = await api.post<RequestPassResponse>('/users/request-password-reset', { email });
+  return response.data;
+}
+
+export const resetPassword = async (token: string, newPassword: string): Promise<void> => {
+  try {
+    const response = await api.post("/users/reset-password", { token, newPassword });
+    return response.data;
+  } catch {
+    throw new Error("Error al restablecer la contraseña");
+  }
+};

--- a/refuerzo-web/types/types.ts
+++ b/refuerzo-web/types/types.ts
@@ -17,6 +17,11 @@ export interface PartialPostulant {
   createdAt?: string;
 }
 
+export interface RequestPassResponse {
+  statusCode: number;
+  message: string;
+}
+
 export interface CompletePostulant {
   _id: string;
   nombre: string;


### PR DESCRIPTION
This pull request includes significant changes to the password reset functionality, including the addition of a reset password page and updates to the login form to handle password reset requests.

Password reset functionality:

* [`refuerzo-web/app/reset-password/page.tsx`](diffhunk://#diff-bd2b497010aa6ee15d9a77f571c58867c86056c382db417324a25c7c624758e1R1-R105): Added a new reset password page component that handles the token validation, new password input, and submission process.
* [`refuerzo-web/components/Login/LoginForm.tsx`](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR9-R23): Integrated password reset request functionality, including a popup for requesting a password reset link and handling the response. [[1]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR9-R23) [[2]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR57-R90) [[3]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR99-R114) [[4]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR172-R232)

Service updates:

* [`refuerzo-web/services/user.service.ts`](diffhunk://#diff-3139638c63e0b3e8360bf13879c23f70964ea8e13225dacd5d2ed4c032a3bd67L3-R3): Added `requestPasswordReset` and `resetPassword` functions to handle API requests for password reset. [[1]](diffhunk://#diff-3139638c63e0b3e8360bf13879c23f70964ea8e13225dacd5d2ed4c032a3bd67L3-R3) [[2]](diffhunk://#diff-3139638c63e0b3e8360bf13879c23f70964ea8e13225dacd5d2ed4c032a3bd67R15-R28)

Type updates:

* [`refuerzo-web/types/types.ts`](diffhunk://#diff-e117246de9bc3b8ee8c9ecc80c955310cc33c00c001c2faf4eaf2eeb2b8d3d70R20-R24): Added `RequestPassResponse` interface to define the structure of the password reset response.