### PR TITLE
Add Geolocation service

### DIFF
--- a/refuerzo-apiv2/package.json
+++ b/refuerzo-apiv2/package.json
@@ -37,6 +37,7 @@
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "geoip-lite": "^1.4.10",
     "joi": "^17.13.3",
     "mongodb": "^6.10.0",
     "multer": "^1.4.5-lts.1",
@@ -45,7 +46,8 @@
     "rxjs": "^7.8.1",
     "sharp": "^0.33.5",
     "slugify": "^1.6.6",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "ua-parser-js": "^2.0.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/refuerzo-apiv2/src/auth/auth.controller.ts
+++ b/refuerzo-apiv2/src/auth/auth.controller.ts
@@ -7,14 +7,14 @@ import {
   Param,
   Delete,
   UseGuards,
-  Request,
+  Req,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthDto } from './dto/auth.dto';
 import { PageverifyDto } from './dto/pageverify.dto';
 import { ApiBasicAuth, ApiBearerAuth } from '@nestjs/swagger';
 import { Public } from 'src/common/decorators/public.decorators';
-
+import { Request } from 'express';
 @Controller('auth')
 @ApiBasicAuth()
 export class AuthController {
@@ -22,7 +22,9 @@ export class AuthController {
 
   @Post('login')
   @Public()
-  login(@Body() authDto: AuthDto) {
-    return this.authService.login(authDto);
+  login(@Body() authDto: AuthDto, @Req() req: Request) {
+    const ipAddress = req.ip || req.connection.remoteAddress; // Obtener la dirección IP
+    const userAgent = req.headers['user-agent'] || 'Unknown'; // Obtener el User-Agent
+    return this.authService.login(authDto, ipAddress, userAgent);
   }
 }

--- a/refuerzo-apiv2/src/auth/auth.module.ts
+++ b/refuerzo-apiv2/src/auth/auth.module.ts
@@ -11,12 +11,15 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RolesModule } from 'src/roles/roles.module';
 import { AuthGuard } from './auth.guard';
 import { APP_GUARD } from '@nestjs/core';
+import { LoginAudit } from './entities/loginAudith.entity';
+import { GeoLocationModule } from './geolocation.module';
 
 @Module({
   imports: [
     CommonModule,
     UsersModule,
     RolesModule,
+    GeoLocationModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -26,7 +29,7 @@ import { APP_GUARD } from '@nestjs/core';
         signOptions: { expiresIn: '2h' },
       }),
     }),
-    TypeOrmModule.forFeature([Tokens]),
+    TypeOrmModule.forFeature([Tokens, LoginAudit]),
   ],
   controllers: [AuthController],
   providers: [

--- a/refuerzo-apiv2/src/auth/auth.service.ts
+++ b/refuerzo-apiv2/src/auth/auth.service.ts
@@ -13,6 +13,10 @@ import { Tokens } from './entities/token.entity';
 import { CreateTokensDto } from './dto/create-tokens.dto';
 import { PageverifyDto } from './dto/pageverify.dto';
 import { PermisionOptions, Role } from 'src/roles/entities/role.entity';
+import { LoginAudit } from './entities/loginAudith.entity';
+import { GeoLocationService } from './geolocation.service';
+import { UAParser } from 'ua-parser-js';
+import { ObjectId } from 'typeorm';
 
 @Injectable()
 export class AuthService {
@@ -20,6 +24,9 @@ export class AuthService {
   private readonly authcrudHelper: CrudHelper<Tokens>;
   private readonly rolecrudHelper: CrudHelper<Role>;
   constructor(
+    @InjectRepository(LoginAudit)
+    private readonly loginAuditRepository: Repository<LoginAudit>,
+    private readonly geoLocationService: GeoLocationService,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     @InjectRepository(Role)
@@ -36,7 +43,7 @@ export class AuthService {
     this.rolecrudHelper = new CrudHelper<Role>(this.roleRepository, 'Roles');
   }
 
-  async login(authDto: AuthDto): Promise<GeneralResponseDto<auth>> {
+  async login(authDto: AuthDto, ipAddress: string, userAgent: string): Promise<GeneralResponseDto<auth>> {
     const user = await this.UsercrudHelper.findOne(
       {
         where: { email: authDto.email },
@@ -117,6 +124,24 @@ export class AuthService {
       {},
     );
 
+    const location = this.geoLocationService.getLocation(ipAddress);
+    const parser = new UAParser(userAgent);
+    const result = parser.getResult();
+    const device = result.device.type || 'Desktop'; // Móvil, Tablet, etc.
+    const browser = result.browser.name || 'Unknown'; // Navegador
+
+    await this.logLoginAttempt(
+      user._id.toString(),
+      user.email,
+      ipAddress,
+      userAgent,
+      device,
+      browser,
+      location.country,
+      location.region,
+    );
+
+
     return (
       new GeneralResponseBuilder<auth>()
         .setStatusCode(200)
@@ -126,4 +151,43 @@ export class AuthService {
         .build()
     );
   }
+
+  private async logLoginAttempt(
+    userId: string,
+    email: string,
+    ipAddress: string,
+    userAgent: string,
+    device: string,
+    browser: string,
+    country: string,
+    region: string,
+  ): Promise<void> {
+    const newLog = this.loginAuditRepository.create({
+      userId,
+      email,
+      ipAddress,
+      userAgent,
+      device,
+      browser,
+      country,
+      region,
+    });
+
+    await this.loginAuditRepository.save(newLog);
+
+    const userLogs = await this.loginAuditRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (userLogs.length > 3) {
+      const logsToDelete = userLogs.slice(3);
+      for (const log of logsToDelete) {
+        log.expired = true;
+        await this.loginAuditRepository.save(log);
+      }
+    }
+  }
+
+
 }

--- a/refuerzo-apiv2/src/auth/entities/login-audit.entity.ts
+++ b/refuerzo-apiv2/src/auth/entities/login-audit.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class LoginAudit {
+@PrimaryGeneratedColumn()
+id: number;
+
+@Column()
+userId: number;
+
+@Column()
+ipAddress: string;
+
+@Column()
+userAgent: string;
+
+@Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+loginAt: Date;
+}
+

--- a/refuerzo-apiv2/src/auth/entities/loginAudith.entity.ts
+++ b/refuerzo-apiv2/src/auth/entities/loginAudith.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ObjectIdColumn,
+} from 'typeorm';
+
+import { ObjectId } from 'mongodb';
+
+@Entity('login_audit')
+export class LoginAudit {
+
+  @ObjectIdColumn()
+  _id: ObjectId;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  ipAddress: string;
+
+  @Column()
+  userAgent: string;
+
+  @Column()
+  device: string;
+
+  @Column()
+  browser: string;
+
+  @Column({ nullable: true })
+  country: string;
+
+  @Column({ nullable: true })
+  region: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ default: false })
+  expired: boolean;
+}

--- a/refuerzo-apiv2/src/auth/geolocation.module.ts
+++ b/refuerzo-apiv2/src/auth/geolocation.module.ts
@@ -1,0 +1,9 @@
+// geo-location.module.ts
+import { Module } from '@nestjs/common';
+import { GeoLocationService } from './geolocation.service';
+
+@Module({
+  providers: [GeoLocationService],
+  exports: [GeoLocationService]  
+})
+export class GeoLocationModule {}

--- a/refuerzo-apiv2/src/auth/geolocation.service.ts
+++ b/refuerzo-apiv2/src/auth/geolocation.service.ts
@@ -1,0 +1,13 @@
+import * as geoip from 'geoip-lite';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GeoLocationService {
+  getLocation(ipAddress: string): { country?: string; region?: string } {
+    const geo = geoip.lookup(ipAddress);
+    return {
+      country: geo?.country || 'Unknown',
+      region: geo?.region || 'Unknown',
+    };
+  }
+}

--- a/refuerzo-apiv2/src/main.ts
+++ b/refuerzo-apiv2/src/main.ts
@@ -8,8 +8,14 @@ import { ThrottlerExceptionFilter } from './users/ThrottlerExceptionFilter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const expressInstance = app.getHttpAdapter().getInstance();
+  
   const configService = app.get(ConfigService);
 
+  //add trust proxy
+  expressInstance.set('trust proxy', true);
+  
   app.enableCors({
     origin: [
       'http://localhost:3000',

--- a/refuerzo-apiv2/yarn.lock
+++ b/refuerzo-apiv2/yarn.lock
@@ -2113,6 +2113,14 @@
   dependencies:
     "@types/express" "*"
 
+"@types/node-fetch@^2.6.12":
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.12.tgz#8ab5c3ef8330f13100a7479e2cd56d3386830a03"
+  integrity sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node@*":
   version "22.10.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.10.tgz#85fe89f8bf459dc57dfef1689bd5b52ad1af07e6"
@@ -2618,6 +2626,13 @@ asap@^2.0.0:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+"async@2.1 - 2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 async@^3.2.3:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
@@ -2839,6 +2854,11 @@ bson@^6.10.1:
   resolved "https://registry.yarnpkg.com/bson/-/bson-6.10.1.tgz#dcd04703178f5ecf5b25de04edd2a95ec79385d3"
   integrity sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -2932,7 +2952,7 @@ caniuse-lite@^1.0.30001688:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz#39dfedd8f94851132795fdf9b79d29659ad9c4d4"
   integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
 
-chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
+"chalk@4.1 - 4.1.2", chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3336,6 +3356,11 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+detect-europe-js@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/detect-europe-js/-/detect-europe-js-0.1.2.tgz#aa76642e05dae786efc2e01a23d4792cd24c7b88"
+  integrity sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==
 
 detect-libc@^2.0.0, detect-libc@^2.0.3:
   version "2.0.3"
@@ -3791,6 +3816,13 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
+
 figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -3982,6 +4014,19 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+geoip-lite@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/geoip-lite/-/geoip-lite-1.4.10.tgz#138256ba97f1abee1afdec78df97a78d320c50f6"
+  integrity sha512-4N69uhpS3KFd97m00wiFEefwa+L+HT5xZbzPhwu+sDawStg6UN/dPwWtUfkQuZkGIY1Cj7wDVp80IsqNtGMi2w==
+  dependencies:
+    async "2.1 - 2.6.4"
+    chalk "4.1 - 4.1.2"
+    iconv-lite "0.4.13 - 0.6.3"
+    ip-address "5.8.9 - 5.9.4"
+    lazy "1.0.11"
+    rimraf "2.5.2 - 2.7.1"
+    yauzl "2.9.2 - 2.10.0"
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -4182,6 +4227,13 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+"iconv-lite@0.4.13 - 0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4280,6 +4332,15 @@ inquirer@9.2.15:
     strip-ansi "^6.0.1"
     wrap-ansi "^6.2.0"
 
+"ip-address@5.8.9 - 5.9.4":
+  version "5.9.4"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-5.9.4.tgz#4660ac261ad61bd397a860a007f7e98e4eaee386"
+  integrity sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==
+  dependencies:
+    jsbn "1.1.0"
+    lodash "^4.17.15"
+    sprintf-js "1.1.2"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -4373,6 +4434,11 @@ is-regex@^1.2.1:
     gopd "^1.2.0"
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
+
+is-standalone-pwa@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz#7a1b0459471a95378aa0764d5dc0a9cec95f2871"
+  integrity sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -4886,6 +4952,11 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
+
 jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
@@ -4985,6 +5056,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+lazy@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/lazy/-/lazy-1.0.11.tgz#daa068206282542c088288e975c297c1ae77b690"
+  integrity sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -5072,7 +5148,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@4.17.21, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5392,7 +5468,7 @@ node-emoji@1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -5625,6 +5701,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
@@ -5879,6 +5960,13 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+"rimraf@2.5.2 - 2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -5929,7 +6017,7 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6184,6 +6272,11 @@ sparse-bitfield@^3.0.3:
   integrity sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==
   dependencies:
     memory-pager "^1.0.2"
+
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -6606,6 +6699,22 @@ typescript@^5.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
+ua-is-frozen@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz#bfbc5f06336e379590e36beca444188c7dc3a7f3"
+  integrity sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==
+
+ua-parser-js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-2.0.2.tgz#fe68ea73166479649ce2368e54bfc8d82210ad39"
+  integrity sha512-NoaPjzMmuUlo5bJ2jrdkzvHL8gpcgVrhUugAqsqsundDO3R8rw7R0OwxLoWhcKtsTb+6u3z9dES8m6+vxEcJog==
+  dependencies:
+    "@types/node-fetch" "^2.6.12"
+    detect-europe-js "^0.1.2"
+    is-standalone-pwa "^0.1.1"
+    node-fetch "^2.7.0"
+    ua-is-frozen "^0.1.2"
+
 uid@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/uid/-/uid-2.0.2.tgz#4b5782abf0f2feeefc00fa88006b2b3b7af3e3b9"
@@ -6952,6 +7061,14 @@ yargs@^17.3.1, yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+"yauzl@2.9.2 - 2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yn@3.1.1:
   version "3.1.1"

--- a/refuerzo-web/components/CardViews/StudentCard.tsx
+++ b/refuerzo-web/components/CardViews/StudentCard.tsx
@@ -1,5 +1,5 @@
 import { Estudiante } from "@/types/types";
-import { Mail, Phone, Trash2, Edit2, Repeat2Icon } from "lucide-react";
+import { Mail, Phone, Trash2, Repeat2Icon } from "lucide-react";
 
 interface EstudianteCardProps {
     alumno: Estudiante;


### PR DESCRIPTION
This pull request introduces several significant changes to the `refuerzo-apiv2` project, focusing on enhancing the authentication module with login auditing and geolocation features. The most important changes include adding new dependencies, modifying the `AuthService` to log login attempts with geolocation data, and creating new entities and modules for handling login audits and geolocation.

### Enhancements to Authentication Module:

* **New Dependencies:**
  * Added `geoip-lite` and `ua-parser-js` to `package.json` for geolocation and user-agent parsing. [[1]](diffhunk://#diff-a2f2df38f07aa38e9d812aa8937e7f9570ad521fd92f78d24c33ed20c96d7cd3R40) [[2]](diffhunk://#diff-a2f2df38f07aa38e9d812aa8937e7f9570ad521fd92f78d24c33ed20c96d7cd3L48-R50)

* **Login Auditing:**
  * Modified `auth.controller.ts` to include IP address and user-agent in the login method.
  * Updated `auth.service.ts` to log login attempts, including geolocation data and user-agent details. [[1]](diffhunk://#diff-e6810b0b26df51d2a23fffa8dad940d9bc94b8477fdf2a24ccb8736318fe4c0fL39-R46) [[2]](diffhunk://#diff-e6810b0b26df51d2a23fffa8dad940d9bc94b8477fdf2a24ccb8736318fe4c0fR127-R144) [[3]](diffhunk://#diff-e6810b0b26df51d2a23fffa8dad940d9bc94b8477fdf2a24ccb8736318fe4c0fR154-R192)
  * Added `LoginAudit` entity to store login attempt details. [[1]](diffhunk://#diff-0929a214b2daef12435d1398b93cd9fd3243947dd1e91a2771484ebfb4f55311R1-R20) [[2]](diffhunk://#diff-2270445acd568bb086600d120b904c494cd936b4dd01aed65d424de189fe9995R1-R50)

* **Geolocation Service:**
  * Created `GeoLocationService` and `GeoLocationModule` to provide geolocation functionality. [[1]](diffhunk://#diff-2190642dfff5de8a823961c857cae2a702d771ba161c49d1452bad8285b33519R1-R9) [[2]](diffhunk://#diff-7ca7f3b3eca1b121be126bb34afa4843ab0408fc4d8d56c7cf4d853809a93853R1-R13)

* **Configuration Changes:**
  * Updated `main.ts` to trust proxy headers for accurate IP address retrieval.