### PR TITLE
fix: remove data unnecesary

### DIFF
--- a/refuerzo-apiv2/src/auth/auth.controller.ts
+++ b/refuerzo-apiv2/src/auth/auth.controller.ts
@@ -23,8 +23,8 @@ export class AuthController {
   @Post('login')
   @Public()
   login(@Body() authDto: AuthDto, @Req() req: Request) {
-    const ipAddress = req.ip || req.connection.remoteAddress; // Obtener la dirección IP
-    const userAgent = req.headers['user-agent'] || 'Unknown'; // Obtener el User-Agent
+    const ipAddress = req.ip || req.connection.remoteAddress; 
+    const userAgent = req.headers['user-agent'] || 'Unknown'; 
     return this.authService.login(authDto, ipAddress, userAgent);
   }
 }

--- a/refuerzo-apiv2/src/auth/auth.service.ts
+++ b/refuerzo-apiv2/src/auth/auth.service.ts
@@ -127,18 +127,16 @@ export class AuthService {
     const location = this.geoLocationService.getLocation(ipAddress);
     const parser = new UAParser(userAgent);
     const result = parser.getResult();
-    const device = result.device.type || 'Desktop'; // Móvil, Tablet, etc.
-    const browser = result.browser.name || 'Unknown'; // Navegador
+    const device = result.device.type || 'Desktop'; 
+    const browser = result.browser.name || 'Unknown'; 
 
     await this.logLoginAttempt(
       user._id.toString(),
       user.email,
-      ipAddress,
-      userAgent,
       device,
       browser,
       location.country,
-      location.region,
+
     );
 
 
@@ -155,22 +153,16 @@ export class AuthService {
   private async logLoginAttempt(
     userId: string,
     email: string,
-    ipAddress: string,
-    userAgent: string,
     device: string,
     browser: string,
     country: string,
-    region: string,
   ): Promise<void> {
     const newLog = this.loginAuditRepository.create({
       userId,
       email,
-      ipAddress,
-      userAgent,
       device,
       browser,
       country,
-      region,
     });
 
     await this.loginAuditRepository.save(newLog);

--- a/refuerzo-apiv2/src/auth/entities/loginAudith.entity.ts
+++ b/refuerzo-apiv2/src/auth/entities/loginAudith.entity.ts
@@ -22,12 +22,6 @@ export class LoginAudit {
   email: string;
 
   @Column()
-  ipAddress: string;
-
-  @Column()
-  userAgent: string;
-
-  @Column()
   device: string;
 
   @Column()
@@ -35,9 +29,6 @@ export class LoginAudit {
 
   @Column({ nullable: true })
   country: string;
-
-  @Column({ nullable: true })
-  region: string;
 
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
This pull request focuses on simplifying the login audit process by removing the storage and handling of IP addresses and user agents. The most important changes include updates to the `AuthController`, `AuthService`, and `LoginAudit` entity.

Simplification of login audit process:

* [`refuerzo-apiv2/src/auth/auth.controller.ts`](diffhunk://#diff-50b7ea61f0086b9fd695950662eda210c9fa74560bd18887d570625d87b6fd67L26-R27): Removed the retrieval of IP address and user agent from the login method.
* [`refuerzo-apiv2/src/auth/auth.service.ts`](diffhunk://#diff-e6810b0b26df51d2a23fffa8dad940d9bc94b8477fdf2a24ccb8736318fe4c0fL130-R139): Removed the handling and logging of IP address and user agent in the `logLoginAttempt` method. [[1]](diffhunk://#diff-e6810b0b26df51d2a23fffa8dad940d9bc94b8477fdf2a24ccb8736318fe4c0fL130-R139) [[2]](diffhunk://#diff-e6810b0b26df51d2a23fffa8dad940d9bc94b8477fdf2a24ccb8736318fe4c0fL158-L173)
* [`refuerzo-apiv2/src/auth/entities/loginAudith.entity.ts`](diffhunk://#diff-2270445acd568bb086600d120b904c494cd936b4dd01aed65d424de189fe9995L24-L29): Removed the `ipAddress` and `userAgent` columns from the `LoginAudit` entity.
* [`refuerzo-apiv2/src/auth/entities/loginAudith.entity.ts`](diffhunk://#diff-2270445acd568bb086600d120b904c494cd936b4dd01aed65d424de189fe9995L39-L41): Removed the `region` column from the `LoginAudit` entity.