### PR TITLE
fix: add context in a separate file

### DIFF
--- a/refuerzo-web/app/contexts/course-context.tsx
+++ b/refuerzo-web/app/contexts/course-context.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { Course } from '@/types/types';
+
+export const CourseContext = React.createContext<Course | undefined>(undefined);

--- a/refuerzo-web/app/dashboard/my-courses/[slug]/layout.tsx
+++ b/refuerzo-web/app/dashboard/my-courses/[slug]/layout.tsx
@@ -7,10 +7,10 @@ import { getCourseBySlug } from '@/services/courses.service';
 import { Course } from '@/types/types';
 import { Loading } from '@/components/Loading';
 import { useQuery } from '@tanstack/react-query';
+import { CourseContext } from '@/app/contexts/course-context';
 
 //Este contexto se ha creado para poder compartir los datos del curso por las diferentes tabs y 
 // asi no tener que hacer peticiones a la API en cada tab.
-export const CourseContext = React.createContext<Course | undefined>(undefined);
 
 export default function CourseLayout({ children }: { children: React.ReactNode }) {
 


### PR DESCRIPTION
This pull request includes changes to the `refuerzo-web` project, specifically focusing on the creation and usage of a new `CourseContext` to share course data across different components.

The most important changes include:

### Context Creation:

* [`refuerzo-web/app/contexts/course-context.tsx`](diffhunk://#diff-36d3c56dd1235060abbf267708446e423a326d70c4ae9247be8351eb4592c2d3R1-R4): Added a new `CourseContext` to share course data across components without making repeated API requests.

### Context Usage:

* `refuerzo-web/app/dashboard/my-courses/[slug]/layout.tsx`: Imported the newly created `CourseContext` and removed the redundant context creation from this file. ([refuerzo-web/app/dashboard/my-courses/[slug]/layout.tsxR10-L13](diffhunk://#diff-30ae59f36df43cc3bc8d4e8a4cfb40e5b65356755d08b13121cbd8d84bdc53c6R10-L13))