### PR TITLE
feat: add options to edit and delete publications

### DIFF
--- a/refuerzo-apiv2/src/publicacion/dto/create-publicacion.dto.ts
+++ b/refuerzo-apiv2/src/publicacion/dto/create-publicacion.dto.ts
@@ -22,7 +22,7 @@ export class CreatePublicacionDto {
   @ApiProperty({
     description: 'Categoría de la publicación',
     example: 'anuncio',
-    enum: ['anuncio', 'material de apoyo'], // Define los valores permitidos
+    enum: ['anuncio', 'guia'],
   })
   @IsString()
   @IsNotEmpty()

--- a/refuerzo-web/components/Fields/DocumentSelector.tsx
+++ b/refuerzo-web/components/Fields/DocumentSelector.tsx
@@ -60,6 +60,11 @@ export const MultiFileSelector: React.FC<MultiFileSelectorProps> = ({
 
   const removeItem = (index: number) => {
     setSelectedItems((prev) => prev.filter((_, i) => i !== index));
+
+    if (setFiles) {
+      const updatedFiles = selectedItems.filter((_, i) => i !== index);
+      setFiles(updatedFiles);
+    }
   };
 
   return (

--- a/refuerzo-web/components/Popups/AddPublicationModal.tsx
+++ b/refuerzo-web/components/Popups/AddPublicationModal.tsx
@@ -201,11 +201,12 @@ export const AddPublicationModal = ({
             const processedFiles = await Promise.all(files.map((file) => processFile(file)));
             const documentArray = processedFiles.filter(Boolean) as FilePublicacion[];
 
-            // Se arma el objeto de envío combinando el formulario con los archivos procesados
             const submissionData = { ...formData, files: documentArray };
 
             if (initialData && initialData._id) {
                 await updatePublicationMutation.mutateAsync(submissionData);
+
+                console.log("Publicación actualizada", submissionData);
                 toast.success({
                     text: "Éxito",
                     description: "La publicación se ha actualizado correctamente",


### PR DESCRIPTION
This pull request includes changes to the `refuerzo-apiv2` and `refuerzo-web` projects. The most important changes involve updating the allowed values for a publication category, adding functionality to a file selector component, and logging data in a publication modal.

Changes in `refuerzo-apiv2`:

* [`refuerzo-apiv2/src/publicacion/dto/create-publicacion.dto.ts`](diffhunk://#diff-dcb3e217b691c385c61ee6ccd69e1bb7f4bf0c5f3004fb41d3fd165ed0f1ea70L25-R25): Updated the allowed values for the publication category from `['anuncio', 'material de apoyo']` to `['anuncio', 'guia']`.

Changes in `refuerzo-web`:

* [`refuerzo-web/components/Fields/DocumentSelector.tsx`](diffhunk://#diff-44beef8f368bfc95a7431935d2123022a8296ba242fb9bf7d5a9d8b464649ecdR63-R67): Enhanced the `removeItem` function to update the `setFiles` state when an item is removed.
* [`refuerzo-web/components/Popups/AddPublicationModal.tsx`](diffhunk://#diff-837fce59e6d85c12c8f91a287d207a6a872777b65de8bb6967ab309dfd547898L204-R209): Added a console log to display the updated publication data after a successful update.