### PR TITLE
fix: add enum to guia

### DIFF
--- a/refuerzo-apiv2/src/publicacion/service/publicacion.service.ts
+++ b/refuerzo-apiv2/src/publicacion/service/publicacion.service.ts
@@ -48,7 +48,7 @@ export class PublicacionService {
     userId: string,
     createPublicacionDto: CreatePublicacionDto,
   ) {
-    const categorias = ['anuncio', 'material de apoyo'];
+    const categorias = ['anuncio', 'guia'];
 
     if (!categorias.includes(createPublicacionDto.categoria)) {
       throw new BadRequestException(


### PR DESCRIPTION
This pull request includes a change to the `PublicacionService` class in the `publicacion.service.ts` file. The change updates the list of valid categories for `createPublicacionDto`.

* [`refuerzo-apiv2/src/publicacion/service/publicacion.service.ts`](diffhunk://#diff-1de36771a5ddd1c2c2c88a05b7761d9a3f89e25a50b1ac192e08e49f0399a42fL51-R51): Modified the `categorias` array to include 'anuncio' and 'guia' instead of 'anuncio' and 'material de apoyo'.