### PR TITLE
feat: add login with auth js

### DIFF
--- a/refuerzo-web/app/api/auth/[...nextauth]/route.ts
+++ b/refuerzo-web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,133 @@
+import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { api } from "@/lib/api";
+import { AuthResponse } from "@/types/types";
+
+declare module "next-auth" {
+  interface User {
+    accessToken: string;
+    emailVerified?: Date | null;
+  }
+
+  interface Session {
+    accessToken: string;
+    user: {
+      id?: string | null;
+      name?: string | null;
+      email?: string;
+      image?: string | null;
+      emailVerified?: Date | null;
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken: string;
+    user: {
+      id?: string | null;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      emailVerified?: Date | null;
+    };
+  }
+}
+
+export const authOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        try {
+          const response = await api.post<AuthResponse>("auth/login", {
+            email: credentials.email,
+            password: credentials.password,
+          });
+
+          const { data } = response.data;
+          if (!data?.token || !data?.info) return null;
+
+          return {
+            id: data.info.email,
+            email: data.info.email,
+            name: data.info.nombreCompleto,
+            image: data.info.image,
+            accessToken: data.token,
+            emailVerified: null,
+          };
+        } catch (error) {
+          console.error("Authentication error:", error);
+          return null;
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    async redirect({ url, baseUrl }: { url: string; baseUrl: string; }) {
+      return url.startsWith(baseUrl) ? url : baseUrl;
+    },
+    async jwt({
+      token,
+      user,
+    }: {
+      token: import("next-auth/jwt").JWT;
+      user?: import("next-auth").User;
+    }) {
+      if (user) {
+        token.accessToken = user.accessToken;
+        token.user = {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          image: user.image,
+          emailVerified: user.emailVerified,
+        };
+        
+        token.exp = Math.floor(Date.now() / 1000) + 2 * 60 * 60;
+      }
+      return token;
+    },
+    async session({
+      session,
+      token,
+    }: {
+      session: import("next-auth").Session;
+      token: import("next-auth/jwt").JWT;
+    }) {
+      session.accessToken = token.accessToken;
+      session.user = {
+        id: token.user?.id || "",
+        name: token.user?.name || null,
+        email: token.user?.email || "",
+        image: token.user?.image || null,
+        emailVerified: token.user?.emailVerified || null,
+      };
+      
+      session.expires = token.exp ? new Date(token.exp * 1000).toISOString() : new Date().toISOString();
+      return session;
+    },
+  },
+  secret: process.env.AUTH_SECRET,
+  session: {
+    strategy: "jwt" as const,
+    maxAge: 2 * 60 * 60
+  },
+  jwt: {
+    maxAge: 2 * 60 * 60, 
+  },
+  trustHost: true,
+  pages: {
+    signIn: "/login",
+    error: "/login/error",
+  },
+};
+
+export const {
+  handlers: { GET, POST },
+  auth,
+} = NextAuth(authOptions);

--- a/refuerzo-web/app/auth.ts
+++ b/refuerzo-web/app/auth.ts
@@ -1,0 +1,1 @@
+export { authOptions, auth } from "./api/auth/[...nextauth]/route"

--- a/refuerzo-web/app/dashboard/layout.tsx
+++ b/refuerzo-web/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/hooks/useAuth";
 import UpdateRequiredForm from "@/components/Auth/UpdateRequiredForm";
 import { Loading } from "@/components/Loading";
 import { GoogleReCaptchaProvider } from "react-google-recaptcha-v3";
+import { useSession } from "next-auth/react";
 
 interface LayoutProps {
     children: React.ReactNode;
@@ -17,19 +18,19 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     const { user } = useAuth();
     const router = useRouter();
     const [isChecking, setIsChecking] = useState(true);
-
+    const { data: session, status } = useSession();
 
     useEffect(() => {
-        const checkAuth = async () => {
-            const isAuthenticated = await AuthService.checkAuth();
-            if (!isAuthenticated) {
-                router.push('/');
-            } else {
-                setIsChecking(false);
-            }
-        };
-        checkAuth();
-    }, [router]);
+        if (status === "unauthenticated") {
+            router.push('/');
+        } else if (status === "authenticated") {
+            setIsChecking(false);
+        }
+    }, [status, router]);
+
+    if (status === "loading" || isChecking) {
+        return <Loading />;
+    }
 
     if (isChecking) {
         return <Loading />;
@@ -43,7 +44,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     return (
         <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
             <div className="w-full flex-none md:w-64">
-                <Sidenav user={user} />
+                <Sidenav />
             </div>
             <main className="flex-grow md:overflow-y-auto mt-20 md:mt-0 z-40 bg-gray-50">
                 <GoogleReCaptchaProvider

--- a/refuerzo-web/app/dashboard/profile/page.tsx
+++ b/refuerzo-web/app/dashboard/profile/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useAuth } from "@/hooks/useAuth";
-import { useAuthStore } from "@/stores/authStore";
 import { getLoginAttempt } from "@/services/auditory.service";
 import {
   UserCircle,
@@ -21,6 +19,8 @@ import {
   Globe,
   Calendar,
 } from "lucide-react";
+import { signOut, useSession } from "next-auth/react";
+
 
 import { toast } from "@pheralb/toast";
 import PageHeader from "@/components/Dashboard/PageHeader";
@@ -67,11 +67,11 @@ const InfoItem = ({
 
 
 export default function ProfilePage() {
-  const { user } = useAuth();
-  const { clearAuth } = useAuthStore();
   const [showForgotPasswordPopup, setShowForgotPasswordPopup] = useState(false);
   const [resetEmail, setResetEmail] = useState("");
   const [resetLoading, setResetLoading] = useState(false);
+  const { data: session } = useSession();
+  const user = session?.user;
 
   const { executeRecaptcha } = useGoogleReCaptcha();
 
@@ -81,7 +81,7 @@ export default function ProfilePage() {
       options: {
         promise: new Promise(() => {
           setTimeout(() => {
-            clearAuth('/');
+            signOut({ callbackUrl: '/' })
           }, 1500);
         }),
         success: "Sesión cerrada con éxito!",
@@ -169,7 +169,7 @@ export default function ProfilePage() {
 
             <div className="text-center md:text-left">
               <h1 className="text-3xl font-bold text-blue_principal mb-2 flex items-center gap-2">
-                {user?.nombreCompleto || "Invitado"}
+                {user?.name || "Invitado"}
               </h1>
               <p className="text-lg text-gray-600 flex items-center justify-center md:justify-start gap-2">
                 <Mail className="w-5 h-5 text-blue_principal" />
@@ -182,7 +182,7 @@ export default function ProfilePage() {
             <InfoItem
               icon={User}
               label="Nombre completo"
-              value={user?.nombreCompleto}
+              value={user?.name}
             />
             <InfoItem
               icon={Mail}

--- a/refuerzo-web/app/layout.tsx
+++ b/refuerzo-web/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
 import { NextUIProvider } from '@nextui-org/react';
 import './globals.css';
+import { ClientInitializer } from "@/components/ClientInitializer"
 import ClientProviders from '@/components/ClientProvider';
 import { Toaster } from "@pheralb/toast";
 import type { Viewport } from 'next'
+import { SessionProvider } from "next-auth/react";
+import { setupAxiosInterceptor } from "@/lib/axios-interceptor";
 
 
 export const viewport: Viewport = {
@@ -24,15 +27,21 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  setupAxiosInterceptor();
+
+
   return (
     <html lang="en">
       <body>
-        <NextUIProvider>
-          <ClientProviders>
-            {children}
-            <Toaster theme="light" />
-          </ClientProviders>
-        </NextUIProvider>
+        <SessionProvider>
+          <NextUIProvider>
+            <ClientProviders>
+              <ClientInitializer />
+              {children}
+              <Toaster theme="light" />
+            </ClientProviders>
+          </NextUIProvider>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/refuerzo-web/app/middleware.ts
+++ b/refuerzo-web/app/middleware.ts
@@ -1,0 +1,1 @@
+export { auth as middleware } from "./auth"

--- a/refuerzo-web/components/ClientInitializer.tsx
+++ b/refuerzo-web/components/ClientInitializer.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { setupAxiosInterceptor } from "@/lib/axios-interceptor";
+import { useEffect } from "react";
+
+export const ClientInitializer = () => {
+  useEffect(() => {
+    setupAxiosInterceptor();
+  }, []);
+
+  return null;
+};

--- a/refuerzo-web/components/Dashboard/Sidenav.tsx
+++ b/refuerzo-web/components/Dashboard/Sidenav.tsx
@@ -2,11 +2,9 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useAuthStore } from "@/stores/authStore";
 import { NavItem } from "./NavItem";
 import { usePathname } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
-import { UserInfo } from "@/types/types";
 import {
   LayoutDashboardIcon,
   UserIcon,
@@ -22,20 +20,17 @@ import {
   Settings,
   Users2Icon
 } from "lucide-react";
-
-interface SidenavProps {
-  user: UserInfo | null;
-}
-
-const Sidenav: React.FC<SidenavProps> = ({ user }) => {
+import { signOut, useSession } from "next-auth/react";
 
 
-  const { clearAuth } = useAuthStore();
+const Sidenav: React.FC = () => {
   const pathName = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
+  const { data: session } = useSession();
+  const user = session?.user;
 
   useEffect(() => {
     setIsMounted(true);
@@ -64,7 +59,7 @@ const Sidenav: React.FC<SidenavProps> = ({ user }) => {
 
   // Handlers
   const toggleMobileMenu = () => setIsMenuOpen((prev) => !prev);
-  const handleLogout = () => clearAuth('/');
+  const handleLogout = () => signOut({ callbackUrl: '/' });
 
   // Skeleton loader para SSR
   if (!isMounted) {
@@ -219,7 +214,7 @@ const Sidenav: React.FC<SidenavProps> = ({ user }) => {
             )}
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium truncate">
-                {user?.nombreCompleto || "Invitado"}
+                {user?.name || "Invitado"}
               </p>
               <p className="text-xs text-gray-600 truncate">
                 {user?.email || "No disponible"}
@@ -309,7 +304,7 @@ const Sidenav: React.FC<SidenavProps> = ({ user }) => {
                 )}
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">
-                    {user?.nombreCompleto || "Invitado"}
+                    {user?.name || "Invitado"}
                   </p>
                   <p className="text-xs text-gray-600 truncate">
                     {user?.email || "No disponible"}

--- a/refuerzo-web/components/Login/LoginForm.tsx
+++ b/refuerzo-web/components/Login/LoginForm.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { ShowPasswordIcon, HidePasswordIcon } from "@/utils/Icons";
-import { AuthService } from "@/services/auth.service";
-import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from 'next/navigation';
 import Image from "next/image";
 import { requestPasswordReset } from "@/services/user.service";
@@ -13,6 +11,7 @@ import ForgotPasswordModal from "../Popups/ForgotPasswordModal";
 import {
   useGoogleReCaptcha
 } from 'react-google-recaptcha-v3';
+import { signIn, useSession } from "next-auth/react";
 
 
 const LoginForm: React.FC = () => {
@@ -27,18 +26,14 @@ const LoginForm: React.FC = () => {
 
   const router = useRouter();
   const { executeRecaptcha } = useGoogleReCaptcha();
+  const { status } = useSession();
+
 
   useEffect(() => {
-    const checkAuth = async () => {
-      const isAuthenticated = await AuthService.checkAuth();
-      if (isAuthenticated) {
-        router.push('/dashboard');
-      }
-    };
-
-    checkAuth();
-  }, [router]);
-
+    if (status === "authenticated") {
+      router.push('/dashboard');
+    }
+  }, [status, router]);
 
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -47,18 +42,34 @@ const LoginForm: React.FC = () => {
     setLoading(true);
 
     try {
-      await AuthService.login({ email, password });
-      router.push('/dashboard');
-    } catch (err: unknown) {
+      "use server"
+      const result = await signIn("credentials", {
+        redirect: false,
+        email,
+        password
+      });
+
+      if (result?.error) {
+        throw new Error(result.error);
+      }
+
+      // Redirigir manualmente después de éxito
+      router.refresh();
+      router.push("/dashboard");
+
+    } catch (err) {
+
       let errorMessage = "Error de autenticación. Por favor intenta de nuevo.";
       if (err instanceof Error) {
         errorMessage = err.message;
       }
       setError(errorMessage);
-      useAuthStore.getState().clearAuth();
-    } finally {
+
+    }
+    finally {
       setLoading(false);
     }
+
   };
 
   const handleForgotPassword = async (e: React.FormEvent) => {
@@ -72,16 +83,14 @@ const LoginForm: React.FC = () => {
         throw new Error("reCAPTCHA no está disponible.");
       }
 
-
       const token = await executeRecaptcha("forgot_password");
 
       const response: RequestPassResponse = await requestPasswordReset(resetEmail, token);
 
-
       if (response && response.statusCode === 404) {
-        toast.error({text: 'Ha ocurrido un error', description: response.message});
+        toast.error({ text: 'Ha ocurrido un error', description: response.message });
       } else {
-        toast.success({text: 'Enlace de recuperación enviado. Revisa tu correo electrónico.'});
+        toast.success({ text: 'Enlace de recuperación enviado. Revisa tu correo electrónico.' });
         setShowForgotPasswordPopup(false);
       }
     } catch {
@@ -192,9 +201,8 @@ const LoginForm: React.FC = () => {
         </p>
       </form>
 
-      {/* Popup de recuperación de contraseña */}
       {showForgotPasswordPopup && (
-        <ForgotPasswordModal handleForgotPassword={handleForgotPassword} resetEmail={resetEmail} resetLoading={resetLoading} setResetEmail={setResetEmail} setShowForgotPasswordPopup={setShowForgotPasswordPopup} hasLogin={false} /> 
+        <ForgotPasswordModal handleForgotPassword={handleForgotPassword} resetEmail={resetEmail} resetLoading={resetLoading} setResetEmail={setResetEmail} setShowForgotPasswordPopup={setShowForgotPasswordPopup} hasLogin={false} />
       )}
     </div>
   );

--- a/refuerzo-web/lib/axios-interceptor.ts
+++ b/refuerzo-web/lib/axios-interceptor.ts
@@ -1,0 +1,23 @@
+// lib/axios-interceptor.ts
+import { api } from "@/lib/api";
+let isInterceptorSetup = false;
+
+export const setupAxiosInterceptor = () => {
+  if (typeof window === "undefined" || isInterceptorSetup) return;
+
+  api.interceptors.request.use(async (config) => {
+    try {
+      const { getSession } = await import("next-auth/react");
+      const session = await getSession();
+      
+      if (session?.accessToken) {
+        config.headers.Authorization = `Bearer ${session.accessToken}`;
+      }
+    } catch (error) {
+      console.error("Interceptor error (client-side only):", error);
+    }
+    return config;
+  });
+
+  isInterceptorSetup = true;
+};

--- a/refuerzo-web/package-lock.json
+++ b/refuerzo-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "refuerzo-web",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/core": "^0.38.0",
         "@google-recaptcha/react": "^1.2.3",
         "@headlessui/react": "^2.2.0",
         "@nextui-org/react": "^2.4.8",
@@ -21,7 +22,7 @@
         "framer-motion": "^11.18.2",
         "lucide-react": "^0.454.0",
         "next": "15.0.1",
-        "next-auth": "^4.24.10",
+        "next-auth": "^5.0.0-beta.25",
         "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -56,6 +57,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.38.0.tgz",
+      "integrity": "sha512-ClHl44x4cY3wfJmHLpW+XrYqED0fZIzbHmwbExltzroCjR5ts3DLTWzADRba8mJFYZ8JIEJDa+lXnGl0E9Bl7Q==",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -2322,7 +2351,8 @@
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -6566,6 +6596,11 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "dev": true,
@@ -7369,8 +7404,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "license": "MIT",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9119,8 +9155,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "license": "MIT",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.8.tgz",
+      "integrity": "sha512-EyUPtOKyTYq+iMOszO42eobQllaIjJnwkZ2U93aJzNyPibCy7CEvT9UQnaCVB51IAd49gbNdCew1c0LcLTCB2g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -9277,16 +9314,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lucide-react": {
@@ -9482,33 +9509,87 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.11",
-      "license": "ISC",
+      "version": "5.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.25.tgz",
+      "integrity": "sha512-2dJJw1sHQl2qxCrRk+KTQbeH+izFbGFPuJj5eGgBZFYyiYYtvlrBeUw1E/OJJxTRjuxbSYGnCTkUIRsIIW0bog==",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.0",
-        "jose": "^4.15.5",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
+        "@auth/core": "0.37.2"
       },
       "peerDependencies": {
-        "@auth/core": "0.34.2",
-        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0-0",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "react": "^18.2.0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
-        "@auth/core": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
           "optional": true
         },
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-auth/node_modules/@auth/core": {
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.2.tgz",
+      "integrity": "sha512-kUvzyvkcd6h1vpeMAojK2y7+PAV5H+0Cc9+ZlKYDFhDY31AlvsB+GW5vNO4qE3Y07KeQgvNO9U0QUx/fN62kBw==",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.7.1",
+        "jose": "^5.9.3",
+        "oauth4webapi": "^3.0.0",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/next-auth/node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/next-auth/node_modules/preact-render-to-string": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -9544,9 +9625,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "license": "MIT"
+    "node_modules/oauth4webapi": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.3.0.tgz",
+      "integrity": "sha512-ZlozhPlFfobzh3hB72gnBFLjXpugl/dljz1fJSRdqaV2r3D5dmi5lg2QWI0LmUYuazmE+b5exsloEv6toUtw9g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -9664,38 +9749,11 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/openid-client": {
-      "version": "5.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/object-hash": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -9983,19 +10041,18 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.25.4",
-      "license": "MIT",
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "5.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "pretty-format": "^3.8.0"
-      },
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -10010,7 +10067,8 @@
     },
     "node_modules/pretty-format": {
       "version": "3.8.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -11179,13 +11237,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "license": "ISC",
@@ -11384,10 +11435,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/refuerzo-web/package.json
+++ b/refuerzo-web/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@auth/core": "^0.38.0",
     "@google-recaptcha/react": "^1.2.3",
     "@headlessui/react": "^2.2.0",
     "@nextui-org/react": "^2.4.8",
@@ -22,7 +23,7 @@
     "framer-motion": "^11.18.2",
     "lucide-react": "^0.454.0",
     "next": "15.0.1",
-    "next-auth": "^4.24.10",
+    "next-auth": "^5.0.0-beta.25",
     "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/refuerzo-web/services/auth.service.ts
+++ b/refuerzo-web/services/auth.service.ts
@@ -1,44 +1,48 @@
 import { api } from "@/lib/api";
-import { AuthResponse } from "@/types/types";
-import { useAuthStore } from "@/stores/authStore";
+import { signIn, signOut, getSession } from "next-auth/react";
+import { Session } from "next-auth";
 
 export const AuthService = {
-  async login(credentials: { email: string; password: string }) {
-    const response = await api.post<AuthResponse>("auth/login", credentials);
-
-    if (response.data.statusCode === 200) {
-      const { token, info: user } = response.data.data;
-      sessionStorage.setItem("authToken", token);
-      sessionStorage.setItem("userInfo", JSON.stringify(user));
-      
-      useAuthStore.getState().setAuth(token, user);
-      return response.data.data;
+  async getAccessToken(): Promise<string | null> {
+    try {
+      const session = await getSession();
+      return session?.accessToken || null;
+    } catch (error) {
+      console.error("Error getting access token:", error);
+      return null;
     }
-    throw new Error("Error de autenticación");
   },
-  async checkAuth(): Promise<boolean> {
-    const token = sessionStorage.getItem("authToken"); 
 
-    if (!token) return false;
+  async login(credentials: { email: string; password: string }): Promise<Session | null> {
+    const response = await signIn("credentials", {
+      redirect: false,
+      ...credentials,
+    });
+    console.log(response);
+    if (response?.error) throw new Error(response.error);
+    
+    const session = await getSession();
+    return session;
+  },
 
-    return true;
+  async logout(): Promise<void> {
+    await signOut({ redirect: false });
   },
 
 };
 
 api.interceptors.request.use(async (config) => {
-  if (typeof window !== 'undefined') {
+  console.log("Request interceptor")
+  if (typeof window !== "undefined") {
     try {
-      const token = sessionStorage.getItem("authToken");
-      
+      const token = await AuthService.getAccessToken();
+      console.log("Token:", token);
       if (token) {
+        config.headers = config.headers || {};
         config.headers.Authorization = `Bearer ${token}`;
-      } else {
-        useAuthStore.getState().clearAuth(); 
       }
     } catch (error) {
-      console.error('Error en interceptor:', error);
-      useAuthStore.getState().clearAuth();
+      console.error("Interceptor error:", error);
     }
   }
   return config;

--- a/refuerzo-web/types/next-auth.d.ts
+++ b/refuerzo-web/types/next-auth.d.ts
@@ -1,0 +1,37 @@
+import "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface User {
+    id: string;
+    email: string;
+    name?: string;
+    image?: string;
+    accessToken: string;
+    emailVerified?: Date | null;
+  }
+
+  interface Session {
+    accessToken: string;
+    user: {
+      id: string;
+      email: string;
+      name?: string;
+      image?: string;
+      emailVerified?: Date | null;
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken: string;
+    user: {
+      id: string;
+      email: string;
+      name?: string;
+      image?: string;
+      emailVerified?: Date | null;
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces significant changes to the authentication system, including the integration of `next-auth` for handling user sessions and authentication. The most important changes include setting up `next-auth` with credentials provider, modifying components to use `next-auth` for session management, and updating the axios interceptor to include the authentication token.

### Authentication Integration:

* `refuerzo-web/app/api/auth/[...nextauth]/route.ts`: Added `next-auth` with a credentials provider for handling user authentication and session management. ([refuerzo-web/app/api/auth/[...nextauth]/route.tsR1-R133](diffhunk://#diff-ffdc2a39716a52a49b90b6ad5021b8d90fca798437b154675708ffdab79cfc9eR1-R133))
* [`refuerzo-web/app/auth.ts`](diffhunk://#diff-eb7f1a4776f1d256f21039a37af0690d022235ef1daf060df6796ebe45ea41d6R1): Exported `authOptions` and `auth` from the new authentication route.
* [`refuerzo-web/app/middleware.ts`](diffhunk://#diff-feae7e09a6848b54bb64dec89653108b7fc9762ca1e3883e7c510186386fe511R1): Exported `auth` as middleware for authentication.

### Component Updates:

* [`refuerzo-web/app/dashboard/layout.tsx`](diffhunk://#diff-c7414fd03f6b129fd1ca40fbfbacb9c819a56bb2efc9c625c82e4f83f0ca2082R11): Replaced custom authentication checks with `useSession` from `next-auth` to manage user sessions. [[1]](diffhunk://#diff-c7414fd03f6b129fd1ca40fbfbacb9c819a56bb2efc9c625c82e4f83f0ca2082R11) [[2]](diffhunk://#diff-c7414fd03f6b129fd1ca40fbfbacb9c819a56bb2efc9c625c82e4f83f0ca2082L20-R33) [[3]](diffhunk://#diff-c7414fd03f6b129fd1ca40fbfbacb9c819a56bb2efc9c625c82e4f83f0ca2082L46-R47)
* [`refuerzo-web/app/dashboard/profile/page.tsx`](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916L4-L5): Updated to use `next-auth` for session management and user information. [[1]](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916L4-L5) [[2]](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916R22-R23) [[3]](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916L70-R74) [[4]](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916L84-R84) [[5]](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916L172-R172) [[6]](diffhunk://#diff-1f7b75f5161c768b2a0944bfc586c1b38ca7cef04fef9c576f6eeb4913b84916L185-R185)
* [`refuerzo-web/components/Dashboard/Sidenav.tsx`](diffhunk://#diff-8c2725e40c38e0b484eba09a865491f93ba7beed1fbaae4bee406a5114f4c83aL5-L9): Modified to use `next-auth` for user session and sign-out functionality. [[1]](diffhunk://#diff-8c2725e40c38e0b484eba09a865491f93ba7beed1fbaae4bee406a5114f4c83aL5-L9) [[2]](diffhunk://#diff-8c2725e40c38e0b484eba09a865491f93ba7beed1fbaae4bee406a5114f4c83aL25-R33) [[3]](diffhunk://#diff-8c2725e40c38e0b484eba09a865491f93ba7beed1fbaae4bee406a5114f4c83aL67-R62) [[4]](diffhunk://#diff-8c2725e40c38e0b484eba09a865491f93ba7beed1fbaae4bee406a5114f4c83aL222-R217) [[5]](diffhunk://#diff-8c2725e40c38e0b484eba09a865491f93ba7beed1fbaae4bee406a5114f4c83aL312-R307)
* [`refuerzo-web/components/Login/LoginForm.tsx`](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bL5-L6): Updated the login form to use `next-auth` for user authentication and session management. [[1]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bL5-L6) [[2]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR14) [[3]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bR29-R36) [[4]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bL50-R72) [[5]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bL75-L80) [[6]](diffhunk://#diff-1bf5ad849e1bed632816b056cb7127c0102b99fe1d6366f0094c0603d92e746bL195)

### Axios Interceptor:

* [`refuerzo-web/lib/axios-interceptor.ts`](diffhunk://#diff-0a58dfafb08295adde422c3de740cc887f18eb4cf6574c4facb77b51328825e4R1-R23): Added an axios interceptor to include the `next-auth` access token in request headers.

### General Setup:

* [`refuerzo-web/app/layout.tsx`](diffhunk://#diff-3d3e5ffa315b82f0e3ebc9fde8f15176b33af42fc0f7ec758081cecdbccd420dR4-R9): Wrapped the application with `SessionProvider` from `next-auth` and set up the axios interceptor. [[1]](diffhunk://#diff-3d3e5ffa315b82f0e3ebc9fde8f15176b33af42fc0f7ec758081cecdbccd420dR4-R9) [[2]](diffhunk://#diff-3d3e5ffa315b82f0e3ebc9fde8f15176b33af42fc0f7ec758081cecdbccd420dR30-R44)
* [`refuerzo-web/components/ClientInitializer.tsx`](diffhunk://#diff-48df29995c8dbba4ca37f15f7add961de7c32c9bac95ce1e228db714aa364a4eR1-R12): Created a client-side initializer to set up the axios interceptor.
* [`refuerzo-web/package-lock.json`](diffhunk://#diff-954ef6a4785f8a73ce13990378bbcd300d5c66129f20ff5af2d53f2f3df03ddaR11): Updated dependencies to include `next-auth` version 5.0.0-beta.25 and `@auth/core`. [[1]](diffhunk://#diff-954ef6a4785f8a73ce13990378bbcd300d5c66129f20ff5af2d53f2f3df03ddaR11) [[2]](diffhunk://#diff-954ef6a4785f8a73ce13990378bbcd300d5c66129f20ff5af2d53f2f3df03ddaL24-R25)