### PR TITLE
fix: add email sender with name

### DIFF
--- a/refuerzo-apiv2/src/email/service/email.service.ts
+++ b/refuerzo-apiv2/src/email/service/email.service.ts
@@ -56,7 +56,7 @@ export class EmailService {
 
   private buildSESParams(sendEmailDto: SendEmailDto): AWS.SES.SendEmailRequest {
     return {
-      Source: `"${this.configService.get('AWS_SES_SENDER_NAME')}" <${sendEmailDto.from || this.configService.get('AWS_SES_SENDER_EMAIL')}>`,
+      Source: `"Refuerzo Escolar Mendoza" <soporte@refuerzo-mendoza.me>`,
       Destination: {
         ToAddresses: sendEmailDto.to,
         CcAddresses: sendEmailDto.cc,


### PR DESCRIPTION
This pull request includes a small change to the `EmailService` class in `refuerzo-apiv2/src/email/service/email.service.ts`. The change updates the `Source` field in the `buildSESParams` method to use a fixed sender name and email address instead of retrieving them from the configuration service.

* [`refuerzo-apiv2/src/email/service/email.service.ts`](diffhunk://#diff-88443d60d52d45ea5ab282a0b19e9b80552941a39fc0391ddac8d1ebb67e335bL59-R59): Updated the `Source` field to use `"Refuerzo Escolar Mendoza" <soporte@refuerzo-mendoza.me>` instead of dynamic values from the configuration service.